### PR TITLE
Removed software vulnerability: Class (ActionSetStructuralFeatureTargetScope) using singleton design pattern has non-private constructor.

### DIFF
--- a/src/argouml-app/src/org/argouml/uml/ui/foundation/core/ActionSetStructuralFeatureTargetScope.java
+++ b/src/argouml-app/src/org/argouml/uml/ui/foundation/core/ActionSetStructuralFeatureTargetScope.java
@@ -62,7 +62,7 @@ public class ActionSetStructuralFeatureTargetScope extends UndoableAction {
     /**
      * Constructor for ActionSetCompositeStateConcurrent.
      */
-    protected ActionSetStructuralFeatureTargetScope() {
+    private ActionSetStructuralFeatureTargetScope() {
         super(Translator.localize("Set"), null);
         // Set the tooltip string:
         putValue(Action.SHORT_DESCRIPTION, 


### PR DESCRIPTION
**Description of the Software Vulnerability:**
Class (ActionSetStructuralFeatureTargetScope) using singleton design pattern has non-private constructor. Given that, it is possible to create a copy of the object, thus violating the singleton pattern.
The easier solution would be making the constructor private.

**Tool Used:**
SpotBugs

**Before Image:**
![image](https://github.com/user-attachments/assets/4ec95a0e-ab1e-4f49-b7fe-7b4232668ad3)

**After Image:**
![image](https://github.com/user-attachments/assets/e789228e-5cb5-41b2-9591-231a3181b8f6)

**Type of Vulnerability:**
Bad practice (BAD_PRACTICE)
Violations of recommended and essential coding practice. Examples include hash code and equals problems, cloneable idiom, dropped exceptions, Serializable problems, and misuse of finalize.